### PR TITLE
Fixed the apostrophe type in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@
 
 def lvVersions = ['2019']
 
-ni.vsbuild.PipelineExecutor.execute(this, 'veristand, 'lvVersions)
+ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

There was a misplaced apostrophe in the Jenkinsfile which made the build to fail instantly.

### Why should this Pull Request be merged?

The build is failing due to the typo in the Jenkinsfile.

### What testing has been done?

n/a
