### PR TITLE
Moved the diffPipeline step back to its previous location (before the build execute command)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@
 
 def lvVersions = ['2019']
 
-ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])
+ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)


### PR DESCRIPTION


- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Moved the diffPipeline step back to its previous location (before the build execute command)

### Why should this Pull Request be merged?

Currently the diff step is executed after the build step. 

### What testing has been done?

Run in a replay and this modification did not cause any trouble in the build process.
