### PR TITLE
Update build label for new server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,4 @@
 def lvVersions = ['2019']
 
 diffPipeline(lvVersions[0])
-ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
+ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses new build node label for NIJENKINS server

### Why should this Pull Request be merged?

Builds will try to use wrong nodes with old label.

### What testing has been done?

Ran replay
