### PR TITLE
Changed the Maintainer from National Instruments to NI

### DIFF
--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: ni-fpga-addon-veristand-{veristand_version}-support
 Version: {nipkg_version}
 Architecture: windows_x64
-Maintainer: National Instruments <support@ni.com>
+Maintainer: NI <support@ni.com>
 XB-Plugin: file
 Description:  This add-on allows a user to pull an existing FPGA bitfile into NI VeriStand with little or no modification.
 XB-Eula: eula-ni-standard


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changed the Maintainer from "National Instruments" to "NI" in order to be aligned with the re-branding

### Why should this Pull Request be merged?

We shouldn't use the old brand name in the newly released products.

### What testing has been done?

This modification does not affect the product's functionality so no testing has been done!
