### PR TITLE
FPGA Addon now appears under the National Instruments menu, in System Explorer

### DIFF
--- a/Source/Addon/Custom Device FPGA Addon.xml
+++ b/Source/Addon/Custom Device FPGA Addon.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>FPGA Addon</eng>
-    <loc>FPGA Addon</loc>
+    <eng>National Instruments::FPGA Addon</eng>
+    <loc>National Instruments::FPGA Addon</loc>
   </AddMenu>
   <Version>3.1.1</Version>
   <Type>Inline HW Interface</Type>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Currently the FPGA Addon Custom Device appears outside(under) the National Instruments right click menu, which appears when trying to add a new custom device in the System Explorer. This PR fixes this issue.

### Why should this Pull Request be merged?

Currently the FPGA Addon Custom Device appears outside(under) the National Instruments right click menu, which appears when trying to add a new custom device in the System Explorer. 

### What testing has been done?

Built the CD locally, and verified if the fix actually fixed the issue in the System Explorer.
