### PR TITLE
Changed the "VeriStand" to "NIVeriStand" in the Custom Device FPGA Addon.xml (ni-rt path)

### DIFF
--- a/Source/Addon/Custom Device FPGA Addon.xml
+++ b/Source/Addon/Custom Device FPGA Addon.xml
@@ -24,7 +24,7 @@
 				<Type>To Common Doc Dir</Type>
 				<Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Engine Windows.llb\RT Driver VI.vi</Path>
 			</Source>
-			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
+			<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
 		</Source>
         <Source>
 			<SupportedTarget>Pharlap</SupportedTarget>
@@ -32,7 +32,7 @@
 			  <Type>To Common Doc Dir</Type>
 			  <Path>Custom Devices\FPGA Addon\Pharlap\FPGA Addon Engine Pharlap.llb\RT Driver VI.vi</Path>
 			</Source>
-			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
+			<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
 		</Source>
     <Source>
       <SupportedTarget>VxWorks</SupportedTarget>
@@ -40,7 +40,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\FPGA Addon\VxWorks\FPGA Addon Engine VxWorks.llb\RT Driver VI.vi</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine VxWorks.llb\RT Driver VI.vi</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine VxWorks.llb\RT Driver VI.vi</RealTimeSystemDestination>
     </Source>
     <Source>
 			<SupportedTarget>Linux_32_ARM</SupportedTarget>
@@ -48,7 +48,7 @@
 				<Type>To Common Doc Dir</Type>
 				<Path>Custom Devices\FPGA Addon\Linux_32_ARM\FPGA Addon Engine LinuxARM.llb\RT Driver VI.vi</Path>
 			</Source>
-			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
+			<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
 		</Source>
 		<Source>
 			<SupportedTarget>Linux_x64</SupportedTarget>
@@ -56,7 +56,7 @@
 				<Type>To Common Doc Dir</Type>
 				<Path>Custom Devices\FPGA Addon\Linux_x64\FPGA Addon Engine Linux64.llb\RT Driver VI.vi</Path>
 			</Source>
-			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Linux64.llb\RT Driver VI.vi</RealTimeSystemDestination>
+			<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Linux64.llb\RT Driver VI.vi</RealTimeSystemDestination>
 		</Source>
 	</SourceDistribution>
 	</CustomDeviceVI>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

In the IA CD in the ni-rt path we used "NIVeriStand" instead of "VeriStand". This pull request makes this modification.

### Why should this Pull Request be merged?

We are trying to standardize the paths where the CDs supported by NI will get once they are copied to the RT Target. Please note that this change does not require mutation code.

### What testing has been done?

n/a
