### PR TITLE
Fixed VS freeze bug by leaving the "Delete Multiple Items" options only on tree options not requiring implicit page refresh 

### DIFF
--- a/Source/Addon/Custom Device FPGA Addon.xml
+++ b/Source/Addon/Custom Device FPGA Addon.xml
@@ -252,21 +252,6 @@
         <Type>To Common Doc Dir</Type>
 		    <Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Configuration.llb\Scalar Inputs.vi</Path>
       </Item2Launch>
-      <RunTimeMenu>
-        <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
-      </RunTimeMenu>
     </Page>
     <Page>
       <Name>
@@ -282,21 +267,6 @@
         <Type>To Common Doc Dir</Type>
 		    <Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Configuration.llb\Scalar Inputs.vi</Path>
       </Item2Launch>
-      <RunTimeMenu>
-        <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
-      </RunTimeMenu>
     </Page>
     <Page>
       <Name>
@@ -314,21 +284,6 @@
         <Type>To Common Doc Dir</Type>
 		    <Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Configuration.llb\Scalar Outputs.vi</Path>
       </Item2Launch>
-      <RunTimeMenu>
-        <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
-      </RunTimeMenu>
     </Page>
     <Page>
       <Name>
@@ -344,21 +299,6 @@
         <Type>To Common Doc Dir</Type>
 		    <Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Configuration.llb\Scalar Outputs.vi</Path>
       </Item2Launch>
-      <RunTimeMenu>
-        <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
-      </RunTimeMenu>
     </Page>
     <Page>
       <Name>
@@ -409,21 +349,6 @@
         <Type>To Common Doc Dir</Type>
 		    <Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Configuration.llb\Waveform Inputs.vi</Path>
       </Item2Launch>
-      <RunTimeMenu>
-        <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
-      </RunTimeMenu>
     </Page>
     <Page>
       <Name>
@@ -442,21 +367,6 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\FPGA Addon\Windows\FPGA Addon Configuration.llb\Waveform Outputs.vi</Path>
       </Item2Launch>
-      <RunTimeMenu>
-        <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
-      </RunTimeMenu>
     </Page>
     <Page>
       <Name>
@@ -604,19 +514,6 @@
               <Path>.</Path>
             </Item2Launch>
           </MenuItem>
-          <MenuItem>
-          <GUID>03D3BE0A-1485-13A6-563AEB9BF271825A</GUID>
-          <Type>VI</Type>
-          <MinNrOfChilds>1</MinNrOfChilds>
-          <Name>
-            <eng>Delete Multiple Items</eng>
-            <loc>Delete Multiple Items</loc>
-          </Name>
-          <Item2Launch>
-            <Type>Absolute</Type>
-            <Path>Dialogs\Delete Multiple Items.vi</Path>
-          </Item2Launch>
-        </MenuItem>
       </RunTimeMenu>
     <ButtonList>
         <Button>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This pull request fixes a bug which caused NI VeriStand System Explorer to enter in a frozen state. 

### Why should this Pull Request be merged?

Currently when deleting Scalars or Waveforms using the Delete Multiple Items option from the tree, the System Explorer enters an unresponsive state and must be closed through task manager. This issue was caused the "Delete multiple items" right-click menu option when it was called in certain pages. The problem was caused by the fact that the Scalar or Waveforms pages are not refreshed when using that delete option from the tree. In order to avoid this showstopper,  the option was removed from several pages and it was left in only Parent elements in the System explorer->FPGA Addon tree such as: Scalar, Waveform; and remove from child elements such as Scalar Inputs, Scalar Outputs, Waveform Inputs, etc. 

### What testing has been done?

After modifying the xml file I built the custom device and tried to reproduce the issue locally, but the bug is not present anymore.
