### PR TITLE
Fixed naming issue in suggested items list (NI FPGA Addon for VeriStand {year})

### DIFF
--- a/control
+++ b/control
@@ -11,5 +11,5 @@ XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {nipkg_version}
-XB-DisplayName: FPGA Addon for VeriStand {veristand_version}
+XB-DisplayName: NI FPGA Addon for VeriStand {veristand_version}
 Depends: {ni-veristand-{veristand_version}} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes the issue where the suggested items list (installer) displays the "FPGA Addon for VeriStand 2020" instead of "NI FPGA Addon for VeriStand 2020"

### Why should this Pull Request be merged?

The installer name is displayed incorrectly in the suggested items list

### What testing has been done?

N/a. Can be tested once the new installers are built
