### PR TITLE
Fixed the issue regarding the incorrect FPGA Addon version number

### DIFF
--- a/control
+++ b/control
@@ -10,6 +10,6 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {nipkg_version}
+XB-DisplayVersion: {display_version}
 XB-DisplayName: NI FPGA Addon for VeriStand {veristand_version}
 Depends: {ni-veristand-{veristand_version}} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

A bug was discovered while testing where the version number of the FPGA Addon entry contains the package version number as well. This shouldn't be the case. This PR fixes the bug. 

![image](https://user-images.githubusercontent.com/62277788/105705285-ad859a00-5f18-11eb-880f-3cfd9df981ba.png)

### Why should this Pull Request be merged?

Currently the version number of the FPGA Addon is displayed incorrectly in the Package Manager during the installation.

### What testing has been done?

n/a. Can be tested once the feed installer gets built.
