### PR TITLE
Fixed the build error where the Scripting Examples were built before the Scripting API

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -14,14 +14,6 @@ path = 'Source\Examples\Scripting API Examples\FPGA Addon Scripting Examples.lvp
 [[build.steps]]
 name = 'Packed Scripting API'
 type = 'lvBuildSpec'
-project = '{api_examples}'
-target = 'My Computer'
-build_spec = 'Scripting Examples'
-dependency_target = 'Windows'
-
-[[build.steps]]
-name = 'Packed Scripting API'
-type = 'lvBuildSpec'
 project = '{cd}'
 target = 'My Computer'
 build_spec = 'Packed Scripting API'
@@ -75,6 +67,14 @@ type = 'lvBuildSpecAllTargets'
 project = '{cd}'
 target = 'RT CompactRIO Target - VxWorks'
 build_spec = 'Engine Release'
+
+[[build.steps]]
+name = 'Scripting Examples'
+type = 'lvBuildSpec'
+project = '{api_examples}'
+target = 'My Computer'
+build_spec = 'Scripting Examples'
+dependency_target = 'Windows'
 
 [[package]]
 type = 'nipkg'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This request changes the order in which the components of the nipkg files are built. It makes the Scripting Examples to be built after the Scripting API buildspec was built.

### Why should this Pull Request be merged?

The Scripting Examples project is dependent on the Scripting API, so building it before building the Scripting API results in build error.

### What testing has been done?

n/a