### PR TITLE
Added the file which was renamed but after that the FPGA Addon System Explorer.lvlib was not save

### DIFF
--- a/Source/Addon/Addon System Explorer/FPGA Addon System Explorer.lvlib
+++ b/Source/Addon/Addon System Explorer/FPGA Addon System Explorer.lvlib
@@ -92,6 +92,7 @@
 			<Item Name="Get Input DMA Refs.vi" Type="VI" URL="../SubVIs/Get Input DMA Refs.vi"/>
 			<Item Name="Get Invalid DMA Configuration.vi" Type="VI" URL="../SubVIs/Get Invalid DMA Configuration.vi"/>
 			<Item Name="Get Invalid Scalar Data Channels.vi" Type="VI" URL="../SubVIs/Get Invalid Scalar Data Channels.vi"/>
+			<Item Name="Get Item Data.vi" Type="VI" URL="../SubVIs/Get Item Data.vi"/>
 			<Item Name="Get Output DMA Refs.vi" Type="VI" URL="../SubVIs/Get Output DMA Refs.vi"/>
 			<Item Name="Get Parent and DMA Type.vi" Type="VI" URL="../SubVIs/Get Parent and DMA Type.vi"/>
 			<Item Name="Get Scalar Bitfile Objects.vi" Type="VI" URL="../SubVIs/Get Scalar Bitfile Objects.vi"/>
@@ -112,7 +113,6 @@
 			<Item Name="Set Bitfile Object Name.vi" Type="VI" URL="../SubVIs/Set Bitfile Object Name.vi"/>
 			<Item Name="Set Bitpacked Channels.vi" Type="VI" URL="../SubVIs/Set Bitpacked Channels.vi"/>
 			<Item Name="Set Group Scalar Channel Data.vi" Type="VI" URL="../SubVIs/Set Group Scalar Channel Data.vi"/>
-			<Item Name="Set Scalar Channel Data.vi" Type="VI" URL="../SubVIs/Set Scalar Channel Data.vi"/>
 			<Item Name="Split DMA by Direction.vi" Type="VI" URL="../SubVIs/Split DMA by Direction.vi"/>
 			<Item Name="Split Registers by Direction.vi" Type="VI" URL="../SubVIs/Split Registers by Direction.vi"/>
 			<Item Name="Update Scalar Channel GUID.vi" Type="VI" URL="../SubVIs/Update Scalar Channel GUID.vi"/>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In PR 85 a bug was introduced. The "Set Scalar Channel Data.vi" was renamed to "Get Item Data.vi" but the FPGA Addon System Explorer.lvlib was not saved. This PR fixes the issue.

### Why should this Pull Request be merged?

Currently several project components are broken and the automated build system is also failing.

### What testing has been done?

Build the Configuration release locally and it passed. A build on the PR will also be performed.
