### PR TITLE
Update build.toml by removing old API project

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -2,9 +2,6 @@
 build_output_dir = 'Built'
 archive_location = '\\nirvana\Measurements\VeriStandAddons\fpga_addon_custom_device'
 
-[projects.sysdefapi]
-path = 'Source\FPGA Addon System Definition API.lvproj'
-
 [projects.cd]
 path = 'Source\FPGA Addon.lvproj'
 
@@ -18,13 +15,6 @@ project = '{cd}'
 target = 'My Computer'
 build_spec = 'Packed Scripting API'
 dependency_target = 'Windows'
-
-[[build.steps]]
-name = 'System Definition API'
-type = 'lvBuildSpec'
-project = '{sysdefapi}'
-target = 'My Computer'
-build_spec = 'System Definition API'
 
 [[build.steps]]
 name = 'Configuration Library'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates build.toml to fix failing build. Failure was caused by a missing lvproj, which was removed intentionally in a previous PR.

### Why should this Pull Request be merged?

Old project that required a build step was removed, thus fixing the CD build.

### What testing has been done?

N/A
