### PR TITLE
Fixed the incorrect controller address in the target.ini file

### DIFF
--- a/Source/Tests/Unit Tests/FPGA Register IO Testing/FPGA Register IO Tests/targets.ini
+++ b/Source/Tests/Unit Tests/FPGA Register IO Testing/FPGA Register IO Tests/targets.ini
@@ -1,5 +1,5 @@
 [Supported Targets]
-PharLap = 10.113.0.224
+PharLap = vs-eco-slave-8880
 
 [Active Configuration]
 Platform = PharLap


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Replaces the IP address in the target.ini file with the IP address of the target used for ATS runs.

### Why should this Pull Request be merged?

With the current IP Address ATS tests will likely fail once the NIR target is not available.

### What testing has been done?

n/a
