### PR TITLE
Removed the image046.jpg from the LabVIEW project

### DIFF
--- a/Source/FPGA Addon.lvproj
+++ b/Source/FPGA Addon.lvproj
@@ -68,7 +68,6 @@
 						<Item Name="image034.png" Type="Document" URL="../Quick Start Documentation/Images/image034.png"/>
 						<Item Name="image035.jpg" Type="Document" URL="../Quick Start Documentation/Images/image035.jpg"/>
 						<Item Name="image045.jpg" Type="Document" URL="../Quick Start Documentation/Images/image045.jpg"/>
-						<Item Name="image046.jpg" Type="Document" URL="../Quick Start Documentation/Images/image046.jpg"/>
 					</Item>
 					<Item Name="FPGA Addon Quick Start Guide.md" Type="Document" URL="../Quick Start Documentation/FPGA Addon Quick Start Guide.md"/>
 				</Item>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This pull request removes a file from the LabVIEW project as it causes the Jenkins build to fail. Please note that the file was removed from the physical folder with PR110 (https://github.com/ni/niveristand-fpga-addon-custom-device/pull/110)
but it was left in the FPGA Addon.lvproj and this caused the Jenkins build to fail with missing file error.

### Why should this Pull Request be merged?

The Jenkins build is failing due to the missing file.

### What testing has been done?

Built the Configuration Build build specification after the file was removed from the project and it passed successfully.
