### PR TITLE
Added the correct example project name into the build.toml file

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -6,7 +6,7 @@ archive_location = '\\nirvana\Measurements\VeriStandAddons\fpga_addon_custom_dev
 path = 'Source\FPGA Addon.lvproj'
 
 [projects.api_examples]
-path = 'Source\Examples\Scripting API Examples\FPGA Addon Scripting Examples.lvproj'
+path = 'Source\Examples\Scripting API Examples\FPGA Addon Scripting API Examples.lvproj'
 
 [[build.steps]]
 name = 'Packed Scripting API'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changes the Scripting API example project name from "FPGA Addon Scripting Examples.lvproj" to "FPGA Addon Scripting API Examples.lvproj" in the build.toml file.

The changes which caused the build failure was introduced in PR #110.

### Why should this Pull Request be merged?

The build is currently failing because the "FPGA Addon Scripting Examples.lvproj" name is no longer valid and it can't be located by the build machine.

### What testing has been done?

N/A
