### PR TITLE
Updated the Main.html as it still contains information about the old supported FXP configuration

### DIFF
--- a/Source/Addon/Support Files/Help/HTML Help Source/Main.html
+++ b/Source/Addon/Support Files/Help/HTML Help Source/Main.html
@@ -31,16 +31,7 @@
 <li>U64
 <li>I64
 <li>SGL
-<li>FXP +16.3
-<li>FXP +/-16.5
-<li>FXP +/-16.7
-<li>FXP +18.3
-<li>FXP +/-20.5
-<li>FXP +/-24.5
-<li>FXP +/-27.5
-<li>FXP +/-32.8
-<li>FXP +/-32.16
-<li>FXP +/-64.32
+<li>FXP
 </ul>
 The integer data types can be converted into a bitpacked Boolean array.</p>
 <p>Enums are not supported. Convert them to a U8, U16, or U32 control or indicator. Clusters are not supported. Even if the clusters are made up of supported types. Items can be grouped by naming them on the FPGA with a (GroupName).(SignalName) format. Support for grouping can only be set on the initialization screen.</p>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Corrects the misleading information in the Main.html file which says that only specific FXP types are supported.

### Why should this Pull Request be merged?

The information about the FXP support is misleading and incorrect in the Main.html page.

### What testing has been done?

Opened the HTML file to see if it's rendered correctly.
