### PR TITLE
Parent custom device under NI in menu

### DIFF
--- a/Source/Addon/Custom Device FPGA Addon.xml
+++ b/Source/Addon/Custom Device FPGA Addon.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>National Instruments::FPGA Addon</eng>
-    <loc>National Instruments::FPGA Addon</loc>
+    <eng>NI::FPGA Addon</eng>
+    <loc>NI::FPGA Addon</loc>
   </AddMenu>
   <Version>3.2.1</Version>
   <Type>Inline HW Interface</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the custom device appear under the "NI" menu item, rather than "National Instruments".

### Why should this Pull Request be merged?

Branding update.

### What testing has been done?

N/A
