### PR TITLE
Disable 2018 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2018','2019','2020']
+def lvVersions = ['2019','2020']
 
 diffPipeline(lvVersions[0])
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Disable 2018 builds of the repo

### Why should this Pull Request be merged?

Preparing for future releases, we are removing 2018 from the build nodes.
Without removing 2018 support from the Jenkinsfile, future builds of main will fail.

### What testing has been done?

None
