### PR TITLE
Only build engines once

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -27,35 +27,6 @@ build_spec = 'Configuration Release'
 name = 'Engine Libraries'
 type = 'lvBuildSpecAllTargets'
 project = '{cd}'
-target = 'My Computer'
-build_spec = 'Engine Release'
-
-[[build.steps]]
-name = 'Engine Libraries'
-type = 'lvBuildSpecAllTargets'
-project = '{cd}'
-target = 'RT PXI Target - Pharlap'
-build_spec = 'Engine Release'
-
-[[build.steps]]
-name = 'Engine Libraries'
-type = 'lvBuildSpecAllTargets'
-project = '{cd}'
-target = 'RT CompactRIO Target - Linux ARM'
-build_spec = 'Engine Release'
-
-[[build.steps]]
-name = 'Engine Libraries'
-type = 'lvBuildSpecAllTargets'
-project = '{cd}'
-target = 'RT CompactRIO Target - Linux x64'
-build_spec = 'Engine Release'
-
-[[build.steps]]
-name = 'Engine Libraries'
-type = 'lvBuildSpecAllTargets'
-project = '{cd}'
-target = 'RT CompactRIO Target - VxWorks'
 build_spec = 'Engine Release'
 
 [[build.steps]]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Only build the engine code once for each target.

### Why should this Pull Request be merged?

The current `build.toml` file is building all 5 engines on each call to `lvBuildSpecAllTargets`. This is building the engine 25 times instead of just the 5 times required and overloading all of our build machines.

### What testing has been done?

None
