### PR TITLE
Support installing packages dependent on LabVIEW 2021

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,5 @@ def lvVersions = [
   64 : ['2021']
 ]
 
-diffPipeline(lvVersions[0])
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)

--- a/build.toml
+++ b/build.toml
@@ -47,13 +47,13 @@ package_output_dir = 'Built'
 [[package]]
 type = 'nipkg'
 payload_dir = 'Built\Packed Scripting API'
-install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\FPGA Addon'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\FPGA Addon'
 control_file = 'control_scripting_api'
 package_output_dir = 'Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Built\Scripting Examples'
-install_destination = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\FPGA Addon'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\FPGA Addon'
 control_file = 'control_scripting_examples'
 package_output_dir = 'Built'

--- a/control_scripting_api
+++ b/control_scripting_api
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI FPGA Addon LabVIEW Support for NI VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-fpga-addon-veristand-{veristand_version}-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-fpga-addon-veristand-{veristand_version}-support (>= {display_version})

--- a/control_scripting_examples
+++ b/control_scripting_examples
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI FPGA Addon LabVIEW Support Examples for NI VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-fpga-addon-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-fpga-addon-veristand-{veristand_version}-labview-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Support installing packages dependent on LabVIEW 2021 by targeting the correct bitness and package name.
Fix duplicated package name string between examples and scripting packages.

### Why should this Pull Request be merged?

Fix ATS execution by allowing 2021 scripting support to be installed.

### What testing has been done?

Verified packages built and installed on both LV 2020 32-bit and 2021 64-bit.
Verified examples could be run in 2021.