### PR TITLE
Update target support in Custom Device XML

### DIFF
--- a/Source/Addon/Custom Device FPGA Addon.xml
+++ b/Source/Addon/Custom Device FPGA Addon.xml
@@ -26,30 +26,6 @@
 			</Source>
 			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
 		</Source>
-        <Source>
-			<SupportedTarget>Pharlap</SupportedTarget>
-			<Source>
-			  <Type>To Common Doc Dir</Type>
-			  <Path>Custom Devices\FPGA Addon\Pharlap\FPGA Addon Engine Pharlap.llb\RT Driver VI.vi</Path>
-			</Source>
-			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
-		</Source>
-    <Source>
-      <SupportedTarget>VxWorks</SupportedTarget>
-      <Source>
-        <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\FPGA Addon\VxWorks\FPGA Addon Engine VxWorks.llb\RT Driver VI.vi</Path>
-      </Source>
-      <RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine VxWorks.llb\RT Driver VI.vi</RealTimeSystemDestination>
-    </Source>
-    <Source>
-			<SupportedTarget>Linux_32_ARM</SupportedTarget>
-			<Source>
-				<Type>To Common Doc Dir</Type>
-				<Path>Custom Devices\FPGA Addon\Linux_32_ARM\FPGA Addon Engine LinuxARM.llb\RT Driver VI.vi</Path>
-			</Source>
-			<RealTimeSystemDestination>c:\ni-rt\VeriStand\Custom Devices\FPGA Addon\FPGA Addon Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
-		</Source>
 		<Source>
 			<SupportedTarget>Linux_x64</SupportedTarget>
 			<Source>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove all target support except for Windows and Linux x64

### Why should this Pull Request be merged?

Fix #149 

### What testing has been done?

Validated in VS 2020 R6 that creating a new instance of the CD does not show dependent file errors in System Explorer.
