### PR TITLE
shorten payloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,14 +55,14 @@ stages:
         - controlFileName: 'control'
           payloadMaps:
             - installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\FPGA Addon'
-              payloadLocation: 'Built\FPGA Addon'
+              payloadLocation: 'FPGA Addon'
 
         - controlFileName: 'control_scripting_api'
           payloadMaps:
             - installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\FPGA Addon'
-              payloadLocation: 'Built\Packed Scripting API'
+              payloadLocation: 'Packed Scripting API'
 
         - controlFileName: 'control_scripting_examples'
           payloadMaps:
             - installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\FPGA Addon'
-              payloadLocation: 'Built\Scripting Examples'
+              payloadLocation: 'Scripting Examples'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
