### PR TITLE
Removing pharlab from active config

### DIFF
--- a/Source/Tests/System Tests/Bitfile Reload Testing/Bitfile Reload Testing/targets.ini
+++ b/Source/Tests/System Tests/Bitfile Reload Testing/Bitfile Reload Testing/targets.ini
@@ -3,4 +3,4 @@ PharLap = vs-eco-slave-8880
 Linux64PXI = vs-eco-slave-8880
 
 [Active Configuration]
-Platform = PharLap
+Platform = Linux64PXI

--- a/Source/Tests/System Tests/DMA Channels Basic Testing/DMA Channels Basic Testing/targets.ini
+++ b/Source/Tests/System Tests/DMA Channels Basic Testing/DMA Channels Basic Testing/targets.ini
@@ -3,4 +3,4 @@ PharLap = vs-eco-slave-8880
 Linux64PXI = vs-eco-slave-8880
 
 [Active Configuration]
-Platform = PharLap
+Platform = Linux64PXI

--- a/Source/Tests/System Tests/DMA Channels Interleaved Testing/DMA Channels Interleaved Testing/targets.ini
+++ b/Source/Tests/System Tests/DMA Channels Interleaved Testing/DMA Channels Interleaved Testing/targets.ini
@@ -3,4 +3,4 @@ PharLap = vs-eco-slave-8880
 Linux64PXI = vs-eco-slave-8880
 
 [Active Configuration]
-Platform = PharLap
+Platform = Linux64PXI

--- a/Source/Tests/System Tests/DMA Waveform Status Channel Testing/DMA Waveform Status Channel Testing/targets.ini
+++ b/Source/Tests/System Tests/DMA Waveform Status Channel Testing/DMA Waveform Status Channel Testing/targets.ini
@@ -3,4 +3,4 @@ PharLap = vs-eco-slave-8880
 Linux64PXI = vs-eco-slave-8880
 
 [Active Configuration]
-Platform = PharLap
+Platform = Linux64PXI

--- a/Source/Tests/System Tests/Scalar Channels Testing/Scalar Channels Testing/targets.ini
+++ b/Source/Tests/System Tests/Scalar Channels Testing/Scalar Channels Testing/targets.ini
@@ -3,4 +3,4 @@ PharLap = vs-eco-slave-8880
 Linux64PXI = vs-eco-slave-8880
 
 [Active Configuration]
-Platform = PharLap
+Platform = Linux64PXI

--- a/Source/Tests/System Tests/Speciality IO Testing/FPGA Addon Speciality IO Tests/targets.ini
+++ b/Source/Tests/System Tests/Speciality IO Testing/FPGA Addon Speciality IO Tests/targets.ini
@@ -3,4 +3,4 @@ PharLap = vs-eco-slave-8880
 Linux64PXI = vs-eco-slave-8880
 
 [Active Configuration]
-Platform = PharLap
+Platform = Linux64PXI


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-fpga-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR will fix the intermittent FPGA Addon test failure.

### Why should this Pull Request be merged?

FPGA add-on no longer support pharlab and this PR will remove pharlab from active configuration.

### What testing has been done?

![image](https://github.com/user-attachments/assets/1ae625bc-9cc4-4277-bcde-5adfa3d0c33c)

